### PR TITLE
Memory Efficiency update in HistoricalJobs

### DIFF
--- a/types/types.ts
+++ b/types/types.ts
@@ -176,6 +176,9 @@ export interface HistoricalJob {
       count: number;
     };
     tres: {
+      requested: {
+        max: any;
+      };
       consumed: any;
     };
     time: {


### PR DESCRIPTION
Adds memory efficiency to historical job report. 
<img width="195" alt="image" src="https://github.com/user-attachments/assets/e9198e42-5e54-4e35-baa2-0d228e2d0118">

Annotates MiB to requested/allocated historical job attributes.
<img width="553" alt="image" src="https://github.com/user-attachments/assets/d444166f-ee0c-4e7f-bf46-10c92b5a6fd9">

Also adds memory efficiency ratios to historical job steps.
<img width="383" alt="image" src="https://github.com/user-attachments/assets/6600de87-f07a-44ce-b705-43fc6c223b2f">


